### PR TITLE
Fix Crash Caused by Removing Observer From Scroll View Instead of the Scroll View's Layer

### DIFF
--- a/MSCMoreOptionTableViewCell/MSCMoreOptionTableViewCell.m
+++ b/MSCMoreOptionTableViewCell/MSCMoreOptionTableViewCell.m
@@ -44,7 +44,7 @@
 }
 
 - (void)dealloc {
-    [self.cellScrollView removeObserver:self forKeyPath:@"sublayers" context:nil];
+    [self.cellScrollView.layer removeObserver:self forKeyPath:@"sublayers" context:nil];
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes a crash that was occurring whenever a cell's dealloc method was called.
