### PR TITLE
Fixed animation behaviour when table view is in edit mode.

### DIFF
--- a/MSCMoreOptionTableViewCell/MSCMoreOptionTableViewCell.m
+++ b/MSCMoreOptionTableViewCell/MSCMoreOptionTableViewCell.m
@@ -186,8 +186,6 @@
 }
 
 - (void)setMoreOptionButtonTitle:(NSString *)title inDeleteConfirmationView:(UIView *)deleteConfirmationView {
-    CGFloat priorMoreOptionButtonFrameWidth = self.moreOptionButton.frame.size.width;
-
     [self.moreOptionButton setTitle:title forState:UIControlStateNormal];
     [self.moreOptionButton sizeToFit];
 
@@ -208,8 +206,9 @@
     self.moreOptionButton.frame = moreOptionButtonFrame;
 
     CGRect rect = deleteConfirmationView.frame;
-    rect.size.width = self.moreOptionButton.frame.origin.x + self.moreOptionButton.frame.size.width + (deleteConfirmationView.frame.size.width - priorMoreOptionButtonFrameWidth);
-    rect.origin.x = deleteConfirmationView.superview.bounds.size.width - rect.size.width;
+    rect.origin.x -= self.moreOptionButton.frame.size.width;
+    rect.size.width += self.moreOptionButton.frame.size.width;
+
     deleteConfirmationView.frame = rect;
 }
 


### PR DESCRIPTION
If the table view is in "Edit" mode, like so: 

![image](https://f.cloud.github.com/assets/213293/2370282/a6276c4e-a7fe-11e3-9428-02bf0ace7040.png)

... then when the left "delete" button is tapped, both the grey and red buttons at the right animate from the left to the right side of the cell very quickly.

This pull request fixes that by properly computing the new position of the buttons, avoiding the need for animation when this happens.
